### PR TITLE
Closes #26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "make-js-component",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "make-js-component",
-      "version": "0.1.5",
+      "version": "0.2.0",
       "license": "ISC",
       "dependencies": {
         "commander": "^11.1.0",

--- a/src/stubs/react/function-component-css-module.jsx
+++ b/src/stubs/react/function-component-css-module.jsx
@@ -1,0 +1,5 @@
+import styles from "./ComponentName.module.css";
+
+export default function ComponentName({}) {
+  return <div className={styles.ComponentName}>Hello ComponentName</div>;
+}

--- a/src/stubs/react/function-component-css-module.tsx
+++ b/src/stubs/react/function-component-css-module.tsx
@@ -1,0 +1,8 @@
+import styles from "./ComponentName.module.css";
+
+interface ComponentNameProps {
+}
+
+export default function ComponentName({}: ComponentNameProps) {
+  return <div className={styles.ComponentName}>Hello ComponentName</div>;
+}

--- a/src/utils/utils.mjs
+++ b/src/utils/utils.mjs
@@ -26,6 +26,12 @@ const createComponent = (componentName, framework, template, customFolder = '') 
             data = data.replaceAll("ComponentName", capitalizeFirstLetter(componentName));
             writeFile(filePathDestination, data);
         }
+        if (template == 'function-component-css-module.jsx'
+            || template == 'function-component-css-module.tsx') {
+            const styleFileName = `${componentName}.module.css`;
+            const styleFilePathDestination = path.join(configs.BASE_DIR, configs.COMPONENT_FOLDER, customFolder, styleFileName);
+            writeFile(styleFilePathDestination, `.${componentName} {\n\tfont-size: 1.125rem; /* 18px */\n\tline-height: 1.75rem; /* 28px */\n\tfont-weight: bold;\n}\n`);
+        }
     });
 };
 export default createComponent;

--- a/src/utils/utils.mts
+++ b/src/utils/utils.mts
@@ -41,7 +41,14 @@ const createComponent = (componentName: string, framework: string, template: str
 			data = data.replaceAll("ComponentName", capitalizeFirstLetter(componentName));
 			writeFile(filePathDestination, data);
 		}
-
+		if (
+            template == 'function-component-css-module.jsx'
+            || template == 'function-component-css-module.tsx'
+        ) {
+            const styleFileName: string = `${componentName}.module.css`;
+            const styleFilePathDestination: string = path.join(configs.BASE_DIR, configs.COMPONENT_FOLDER, customFolder, styleFileName);
+            writeFile(styleFilePathDestination, `.${componentName} {\n\tfont-size: 1.125rem; /* 18px */\n\tline-height: 1.75rem; /* 28px */\n\tfont-weight: bold;\n}\n`);
+        }
 	});
 }
 

--- a/utils/wizard.mjs
+++ b/utils/wizard.mjs
@@ -90,7 +90,7 @@ const wizard = async () => {
                         type: "list",
                         name: "css",
                         message: "Do you want to use any CSS framework?",
-                        choices: ["Tailwind", "Styled Components", "No"],
+                        choices: ["Tailwind", "Styled Components", "CSS Module", "No"],
                     },
                 ]).then((answers) => {
                     const { css } = answers;
@@ -100,6 +100,8 @@ const wizard = async () => {
                             template = "function-component-tailwind.tsx";
                         else if (css === 'Styled Components')
                             template = "function-component-styled-components.tsx";
+                        else if (css === 'CSS Module')
+                            template = "function-component-css-module.tsx";
                         else
                             template = "function-component.tsx";
                     }
@@ -108,6 +110,8 @@ const wizard = async () => {
                             template = "function-component-tailwind.jsx";
                         else if (css === 'Styled Components')
                             template = "function-component-styled-components.jsx";
+                        else if (css === 'CSS Module')
+                            template = "function-component-css-module.jsx";
                         else
                             template = "function-component.jsx";
                     }

--- a/utils/wizard.mts
+++ b/utils/wizard.mts
@@ -111,7 +111,7 @@ const wizard = async () => {
                   type: "list",
                   name: "css",
                   message: "Do you want to use any CSS framework?",
-                  choices: ["Tailwind", "Styled Components", "No"],
+                  choices: ["Tailwind", "Styled Components", "CSS Module", "No"],
                 },
               ]).then((answers: {css: string}) => {
 
@@ -121,10 +121,12 @@ const wizard = async () => {
                 if(typescript){
                   if(css === "Tailwind") template = "function-component-tailwind.tsx"
                   else if(css === 'Styled Components') template = "function-component-styled-components.tsx"
+                  else if(css === 'CSS Module') template = "function-component-css-module.tsx"
                   else template = "function-component.tsx"
                 }else{
                   if(css === "Tailwind") template = "function-component-tailwind.jsx"
                   else if(css === 'Styled Components') template = "function-component-styled-components.jsx"
+                  else if(css === 'CSS Module') template = "function-component-css-module.jsx"
                   else template = "function-component.jsx"
                 }
 


### PR DESCRIPTION
feat(react css modules): including creation of CSS module during the creation of the React component

During the steps of the wizard, once React is selected as the framework, you will be prompted to choose a CSS framework. In this list of options, the 'CSS Module' option has been added. If selected, a new template is used for component generation, and the CSS module is generated and imported into the new component.

closes #26